### PR TITLE
[debian-wheezy] Installed mysql-client

### DIFF
--- a/debian-wheezy/Dockerfile
+++ b/debian-wheezy/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV HOME /root
 
 RUN apt-get update
-RUN apt-get install -y acl vim wget curl git subversion acl htop
+RUN apt-get install -y acl vim wget curl git subversion acl htop mysql-client
 RUN apt-get install -y zip
 
 # install ssh


### PR DESCRIPTION
Certains projets comme les comparateurs ou batchs nécessitent le paquet mysql-client.