### PR TITLE
Install bz2 php extension in php-5.6.20-fpm

### DIFF
--- a/php-5.6.20-fpm/Dockerfile
+++ b/php-5.6.20-fpm/Dockerfile
@@ -163,6 +163,10 @@ RUN apt-get update && apt-get install -y libicu-dev
 RUN pecl install intl
 RUN /usr/local/bin/docker-php-ext-enable intl
 
+#Install PHP Bz2
+RUN apt-get update && apt-get install -y libbz2-dev
+RUN /usr/local/bin/docker-php-ext-install bz2
+
 # paquet libpng-dev for php extention gd
 RUN apt-get update && apt-get install -y \
         wget \


### PR DESCRIPTION
Build OK https://hub.docker.com/r/profideo/php-5.6.20-fpm/builds/bqkp8ui28yymg9ldxx2tdeg/