### PR TITLE
Fix http body size to 100m in nginx of php70

### DIFF
--- a/php70-nginx/files/nginx.conf
+++ b/php70-nginx/files/nginx.conf
@@ -21,6 +21,8 @@ http {
 
     server_names_hash_bucket_size  128;
 
+    client_max_body_size 100m;
+
     access_log  /var/log/nginx/access.log  main;
 
     sendfile        on;


### PR DESCRIPTION
| Q                           | A
| --------------------------- | --------------------------------------
| Fixed issue(s) link(s)      | http://tickets.lesdossiers.com/issues/26631
| Bug fix?                    | no
| New feature?                | yes
| Dependencies with other PRs | https://github.com/Profideo/customer-file-workflow/pull/32 https://github.com/Profideo/exploitation/pull/301 https://github.com/Profideo/customer-file-workflow-api/pull/37
| Testing guidelines          | -
| Deployment guidelines       | -

Build OK https://hub.docker.com/r/profideo/php70-nginx/builds/bmiwrxgfp8m66njwcsytoxm/