### PR TITLE
Remove clamav executions in all images

### DIFF
--- a/php71-nginx/files/supervisord.conf
+++ b/php71-nginx/files/supervisord.conf
@@ -9,9 +9,3 @@ command=/bin/bash -c 'php-fpm --nodaemonize'
 
 [program:nginx]
 command=/bin/bash -c '/usr/sbin/nginx'
-
-[program:clamav]
-command=/bin/bash -c '/etc/init.d/clamav-daemon start'
-
-[program:freshclam]
-command=/bin/bash -c '/usr/bin/freshclam --daemon'

--- a/php72-apache/files/supervisord.conf
+++ b/php72-apache/files/supervisord.conf
@@ -9,9 +9,3 @@ command=/bin/bash -c 'php-fpm --nodaemonize'
 
 [program:apache2]
 command=/bin/bash -c "/usr/sbin/apache2ctl -DFOREGROUND"
-
-[program:clamav]
-command=/bin/bash -c '/etc/init.d/clamav-daemon start'
-
-[program:freshclam]
-command=/bin/bash -c '/usr/bin/freshclam --daemon'

--- a/php73-apache/files/supervisord.conf
+++ b/php73-apache/files/supervisord.conf
@@ -9,9 +9,3 @@ command=/bin/bash -c 'php-fpm --nodaemonize'
 
 [program:apache2]
 command=/bin/bash -c "/usr/sbin/apache2ctl -DFOREGROUND"
-
-[program:clamav]
-command=/bin/bash -c '/etc/init.d/clamav-daemon start'
-
-[program:freshclam]
-command=/bin/bash -c '/usr/bin/freshclam --daemon'


### PR DESCRIPTION
Can take a lot of resources when there are many containers created with these images. Launch clamav manually in containers when need it.